### PR TITLE
Fixed shift overflow checks and change integer literal types to ull

### DIFF
--- a/src/analyzer/ConfigurationProbing.cpp
+++ b/src/analyzer/ConfigurationProbing.cpp
@@ -97,7 +97,6 @@ ConfigurationProbing::execute(const Settings *settings, State *state)
                 if(!var_included) extended_probes.push_back(reg);
             }
 
-            if (extended_probes.size() > 63) throw std::logic_error("PROBING: More than 63 extended probes detected (overflow)!");
         }
         else
         {
@@ -111,13 +110,15 @@ ConfigurationProbing::execute(const Settings *settings, State *state)
 
         this->m_independent = true;
 
+        if (extended_probes.size() > 63) throw std::logic_error("[PROBING]: More than 63 extended probes detected (overflow)!");
+
         /* Check combinations & secrets for statistical independence */
-        for (uint64_t comb = 1; comb < (uint64_t)(1ull << extended_probes.size()) && this->m_independent; comb++)
+        for (uint64_t comb = 1; comb < (1ull << extended_probes.size()) && this->m_independent; comb++)
         {
             /* Generate probe observation */
             BDD observation = state->m_managers[threadNum].bddOne();
             for (uint64_t elem = 0; elem < extended_probes.size(); elem++){
-                if (comb & (1 << elem)) observation &= extended_probes[elem]->functions(threadNum);
+                if (comb & (1ull << elem)) observation &= extended_probes[elem]->functions(threadNum);
             }
 
             /* Statistical independence check */

--- a/src/analyzer/ConfigurationUniformity.cpp
+++ b/src/analyzer/ConfigurationUniformity.cpp
@@ -71,7 +71,7 @@ ConfigurationUniformity::execute(const Settings *settings, State *state)
             for (uint64_t comb = 1; comb < ((1ull << output_shares_map.second.size()) - 1) && this->m_uniform; comb++) {
                 intra[share_cnt].push_back(state->m_managers[0].bddZero());
                 for (unsigned int elem = 0; elem < output_shares_map.second.size(); elem++) {
-                    if (comb & (1 << elem)) intra[share_cnt].back() ^= output_shares_map.second[elem]->functions(0);
+                    if (comb & (1ull << elem)) intra[share_cnt].back() ^= output_shares_map.second[elem]->functions(0);
                 }
 
                 if (abs(state->m_managers[0].bdd_satcountln(intra[share_cnt].back(), this->m_variable_count) - this->m_variable_count + 1) > DOUBLE_COMPARE_THRESHOLD) this->m_uniform = false;

--- a/src/preprocessor/ConfigurationSCA.cpp
+++ b/src/preprocessor/ConfigurationSCA.cpp
@@ -331,9 +331,9 @@ ConfigurationSCA::update_probe_combinations(State *state, const Settings *settin
                         for(auto d : domains) wires.insert(wires.end(), m_outputs_same_domain[d].begin(), m_outputs_same_domain[d].end());
 
                         // create combinations
-                        for(unsigned int comb=1; comb <= ((1 << wires.size())-1); comb++){
+                        for(uint64_t comb=1; comb <= ((1ull << wires.size())-1); comb++){
                             std::vector<const verica::Wire*> new_comb;
-                            for(unsigned int bit=0; bit < wires.size(); bit++){
+                            for(uint64_t bit=0; bit < wires.size(); bit++){
                                 if((comb >> bit) & 1) new_comb.push_back(wires[bit]);
                             }
                             state->m_probe_combinations[thread_num].push_back(std::make_pair(probes, new_comb));


### PR DESCRIPTION
This PR fixes some more issues related to #4 . I'm still not sure if this catches all the cases, but at least it resizes some more integer literals to long long. It also moves the size check to after the virtual probes are added to ensure that it always checks against the actual size of the `extended_probes` vector. 